### PR TITLE
SNAPTX-3458 Address Deprecations from 5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,4 +51,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby_version: ["2.4", "2.5", "2.6", "2.7"]
+              ruby_version: ["2.5", "2.6", "2.7"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,54 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@1.8.0
+references:
+  run_tests: &run_tests
+    run:
+      name: Run test suite
+      command: bundle exec rspec
+  restore: &restore
+    restore_cache:
+      keys:
+        - v1_bundler_deps-{{ checksum "Gemfile.lock" }}-{{ checksum "ruby_version.rev" }}
+  save: &save
+    save_cache:
+      paths:
+        - ./vendor/bundle
+      key: v1_bundler_deps-{{ checksum "Gemfile.lock" }}-{{ checksum "ruby_version.rev" }} # CIRCLE_JOB e.g. "ruby-2.5"
+  bundle: &bundle
+    run:
+      name: install dependencies
+      command: |
+        echo "export BUNDLE_JOBS=4" >> $BASH_ENV
+        echo "export BUNDLE_RETRY=3" >> $BASH_ENV
+        echo "export BUNDLE_PATH=$(pwd)/vendor/bundle" >> $BASH_ENV
+        source $BASH_ENV
+        gem install bundler -v 1.17.3
+        bundle install
+
+jobs:
+  test:
+    parameters:
+      ruby_version:
+        type: string
+    docker:
+      - image: "cimg/ruby:<< parameters.ruby_version >>"
+    environment:
+      RUBY_VERSION: <<parameters.ruby_version>>
+    steps:
+      - checkout
+      - run: sudo apt-get update
+      - run: sudo apt-get install sqlite3 libsqlite3-dev
+      - run: echo "${RUBY_VERSION}" > ruby_version.rev
+      - <<: *restore
+      - <<: *bundle
+      - <<: *run_tests
+      - <<: *save
+
+workflows:
+  all-tests:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              ruby_version: ["2.4", "2.5", "2.6", "2.7"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/
@@ -10,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     state_machinable (4.0.0)
       activesupport (>= 4, < 6)
-      statesman (> 2.0, < 4.0)
+      statesman (> 2.0, < 10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -45,7 +45,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
     sqlite3 (1.4.4)
-    statesman (3.5.0)
+    statesman (9.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    state_machinable (3.1.0)
+    state_machinable (4.0.0)
       activesupport (>= 4, < 6)
       statesman (> 2.0, < 4.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,66 @@
+PATH
+  remote: .
+  specs:
+    state_machinable (3.1.0)
+      activesupport (>= 4, < 6)
+      statesman (> 2.0, < 4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.8.1)
+      activesupport (= 5.2.8.1)
+    activerecord (5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      arel (>= 9.0)
+    activesupport (5.2.8.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (9.0.0)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.15.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (10.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.3)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.4)
+    sqlite3 (1.4.4)
+    statesman (3.5.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.10)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  activerecord (>= 5.1, < 6)
+  bundler
+  pry
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  sqlite3 (~> 1.3)
+  state_machinable!
+
+BUNDLED WITH
+   2.3.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,24 +2,23 @@ PATH
   remote: .
   specs:
     state_machinable (4.0.0)
-      activesupport (>= 4, < 6)
+      activesupport (>= 4, < 7)
       statesman (> 2.0, < 10.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.8.1)
-      activesupport (= 5.2.8.1)
-    activerecord (5.2.8.1)
-      activemodel (= 5.2.8.1)
-      activesupport (= 5.2.8.1)
-      arel (>= 9.0)
-    activesupport (5.2.8.1)
+    activemodel (6.1.7)
+      activesupport (= 6.1.7)
+    activerecord (6.1.7)
+      activemodel (= 6.1.7)
+      activesupport (= 6.1.7)
+    activesupport (6.1.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    arel (9.0.0)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
@@ -46,15 +45,15 @@ GEM
     rspec-support (3.9.4)
     sqlite3 (1.4.4)
     statesman (9.0.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
-  activerecord (>= 5.1, < 6)
+  activerecord (>= 5.1, < 7)
   bundler
   pry
   rake (~> 10.0)

--- a/lib/state_machinable/model.rb
+++ b/lib/state_machinable/model.rb
@@ -13,7 +13,7 @@ module StateMachinable
     end
 
     included do
-      after_save :transition_to_initial_state, :if => Proc.new { |obj| obj.id_changed? }
+      after_save :transition_to_initial_state, :if => Proc.new { |obj| obj.saved_change_to_id? }
       delegate :can_transition_to?, :transition_to!, :transition_to, :to => :state_machine
 
       def state_machine

--- a/lib/state_machinable/version.rb
+++ b/lib/state_machinable/version.rb
@@ -1,3 +1,3 @@
 module StateMachinable
-  VERSION = "3.1.0"
+  VERSION = "4.0.0"
 end

--- a/state_machinable.gemspec
+++ b/state_machinable.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "activerecord", ">= 5.1", "< 6"
+  spec.add_development_dependency "activerecord", ">= 5.1", "< 7"
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_dependency "statesman", "> 2.0", "< 10.0"
-  spec.add_dependency "activesupport", ">= 4", "< 6"
+  spec.add_dependency "activesupport", ">= 4", "< 7"
 end

--- a/state_machinable.gemspec
+++ b/state_machinable.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "activerecord", ">= 5.1", "< 6"
   spec.add_development_dependency "sqlite3", "~> 1.3"
-  spec.add_dependency "statesman", "> 2.0", "< 4.0"
+  spec.add_dependency "statesman", "> 2.0", "< 10.0"
   spec.add_dependency "activesupport", ">= 4", "< 6"
 end

--- a/state_machinable.gemspec
+++ b/state_machinable.gemspec
@@ -27,12 +27,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "activerecord", ">= 4", "< 6"
+  spec.add_development_dependency "activerecord", ">= 5.1", "< 6"
   spec.add_development_dependency "sqlite3", "~> 1.3"
-  spec.add_dependency "statesman", "> 2.0"
+  spec.add_dependency "statesman", "> 2.0", "< 4.0"
   spec.add_dependency "activesupport", ">= 4", "< 6"
 end


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SNAPTX-3458

Relaxes the requirements for ActiveRecord to allow for upstream rails updates.
Relaxes requirements for statesman gem to allow for updates.
Fixes an ActiveRecord::Dirty deprecation (this is breaking for older versions). 
Created a new Major version of the gem to make sure we pay attention to the breaking changes.